### PR TITLE
Autenticación por correo electronico

### DIFF
--- a/backend/src/apps/users/backend.py
+++ b/backend/src/apps/users/backend.py
@@ -1,0 +1,30 @@
+from django.contrib.auth.backends import ModelBackend
+from django.db import OperationalError
+from rest_framework.request import Request
+from typing import Optional
+from apps.users.infrastructure.db import UserRepository
+from apps.users.models import User
+from apps.exceptions import DatabaseConnectionError
+
+
+class EmailBackend(ModelBackend):
+    """
+    A `custom authentication backend` that authenticates users based on their email
+    and password.
+    """
+
+    def authenticate(
+        self, request: Request, email: str, password: str
+    ) -> Optional[User]:
+        try:
+            user = UserRepository.model_user.objects.filter(
+                email=email
+            ).first()
+        except OperationalError:
+            # In the future, a retry system will be implemented when the database is
+            # suddenly unavailable.
+            raise DatabaseConnectionError()
+        if not user:
+            return None
+
+        return user if user.check_password(raw_password=password) else None

--- a/backend/src/apps/users/domain/abstractions.py
+++ b/backend/src/apps/users/domain/abstractions.py
@@ -1,4 +1,4 @@
-from abc import abstractclassmethod, ABC
+from abc import ABC, abstractmethod
 from typing import Dict, Any
 from apps.users.models import User
 
@@ -11,7 +11,8 @@ class IUserRepository(ABC):
 
     model: User
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def create_shelter(cls, data: Dict[str, Any]) -> None:
         """
         Insert a new shelter into the database.

--- a/backend/src/apps/users/domain/typing.py
+++ b/backend/src/apps/users/domain/typing.py
@@ -1,0 +1,41 @@
+from typing import NewType, Dict, Any
+
+
+UserUUID = NewType("UserUUID", str)
+UserUUID.__doc__ = """
+    A unique identifier for a user. For example:
+
+    123e4567-e89b-12d3-a456-426614174000
+"""
+
+
+JWToken = NewType("JWToken", str)
+JWToken.__doc__ = """
+    A JSON Web Token. For example:
+
+    eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+"""
+
+
+AccessToken = NewType("AccessToken", str)
+AccessToken.__doc__ = (
+    "A JSON web token of type access used for authentication."
+)
+
+
+RefreshToken = NewType("RefreshToken", str)
+RefreshToken.__doc__ = "A JSON web token of type refresh that is used to acquire a new access and refresh token."
+
+
+JWTPayload = NewType("JWTPayload", Dict[str, Any])
+JWTPayload.__doc__ = """
+    A dictionary containing the data of a JSON Web Token. For example:
+
+    {
+        'token_type': 'access',
+        'exp': 1711054362,
+        'iat': 1711047162,
+        'jti': '64116c82b8f0439ba52ddff382746e20',
+        'user_id': '2a6b453b-fa2b-4318-9c35-b0e96e894b63'
+    }
+"""

--- a/backend/src/apps/users/models.py
+++ b/backend/src/apps/users/models.py
@@ -5,29 +5,19 @@ from django.contrib.auth.models import (
     PermissionsMixin,
 )
 from phonenumber_field.modelfields import PhoneNumberField
-import uuid
+from uuid import uuid4, UUID
 
 
 class CustomUserManager(UserManager):
     def _create_user(
         self,
-        uuid=None,
-        email=None,
-        password=None,
-        is_active=None,
-        is_staff=None,
-        is_superuser=None,
-        last_login=None,
-        date_joined=None,
+        uuid: UUID = None,
+        email: str = None,
+        password: str = None,
+        **extra_fields,
     ):
         user = self.model(
-            email=self.normalize_email(email),
-            uuid=uuid,
-            is_active=is_active,
-            is_staff=is_staff,
-            is_superuser=is_superuser,
-            last_login=last_login,
-            date_joined=date_joined,
+            uuid=uuid, email=self.normalize_email(email), **extra_fields
         )
         user.set_password(password)
         user.save(using=self._db)
@@ -35,11 +25,9 @@ class CustomUserManager(UserManager):
 
     def create_user(
         self,
-        uuid=None,
-        email=None,
-        password=None,
-        last_login=None,
-        date_joined=None,
+        uuid: UUID = None,
+        email: str = None,
+        password: str = None,
         **extra_fields,
     ):
         """
@@ -51,45 +39,37 @@ class CustomUserManager(UserManager):
         extra_fields.setdefault("is_active", False)
 
         return self._create_user(
-            email=email,
-            uuid=uuid,
-            password=password,
-            last_login=last_login,
-            date_joined=date_joined,
-            **extra_fields,
+            uuid=uuid, email=email, password=password, **extra_fields
         )
 
     def create_superuser(
         self,
-        uuid=None,
-        email=None,
-        password=None,
-        last_login=None,
-        date_joined=None,
+        uuid: UUID = None,
+        email: str = None,
+        password: str = None,
         **extra_fields,
     ):
         extra_fields.setdefault("is_staff", True)
         extra_fields.setdefault("is_superuser", True)
+        extra_fields.setdefault("is_active", True)
 
         if extra_fields.get("is_staff") is not True:
             raise ValueError("Superuser must have is_staff=True.")
         if extra_fields.get("is_superuser") is not True:
             raise ValueError("Superuser must have is_superuser=True.")
+        if extra_fields.get("is_active") is not True:
+            raise ValueError("Active user must have is_active=True.")
 
         return self._create_user(
-            email=email,
             uuid=uuid,
+            email=email,
             password=password,
-            last_login=last_login,
-            date_joined=date_joined,
             **extra_fields,
         )
 
 
 class User(AbstractBaseUser, PermissionsMixin):
-    uuid = models.UUIDField(
-        db_column="uuid", primary_key=True, default=uuid.uuid4
-    )
+    uuid = models.UUIDField(db_column="uuid", primary_key=True, default=uuid4)
     email = models.EmailField(
         db_column="email",
         max_length=90,
@@ -136,9 +116,7 @@ class User(AbstractBaseUser, PermissionsMixin):
 
 
 class Shelter(models.Model):
-    uuid = models.UUIDField(
-        db_column="uuid", primary_key=True, default=uuid.uuid4
-    )
+    uuid = models.UUIDField(db_column="uuid", primary_key=True, default=uuid4)
     user = models.OneToOneField(
         to="User", to_field="uuid", db_column="user", on_delete=models.CASCADE
     )

--- a/backend/src/settings/environments/base.py
+++ b/backend/src/settings/environments/base.py
@@ -108,6 +108,7 @@ AUTH_USER_MODEL = "users.User"
 
 # Model Backend
 AUTHENTICATION_BACKENDS = [
+    "apps.users.backend.EmailBackend",
     "django.contrib.auth.backends.ModelBackend",
 ]
 


### PR DESCRIPTION
## Descripción
Se modifico el `ModelBackend` por defecto de Django, para que sea posible utilizar el correo electrónico como campo necesario para la autenticación en lugar del campo `username` de la configuración predeterminada.